### PR TITLE
warm up the fpga kernels

### DIFF
--- a/benchmark/bench_keyswitch.cpp
+++ b/benchmark/bench_keyswitch.cpp
@@ -149,6 +149,9 @@ BENCHMARK_F(keyswitch, 16384_6_7_7_2)
 
     setup_keyswitch(files);
 
+    // warm up the FPGA kernels specially the twiddle factor dispatching kernel
+    bench_keyswitch();
+
     for (auto st : state) {
         bench_keyswitch();
     }


### PR DESCRIPTION
warm up the fpga kernels specially the twiddle factors dispatching kernel to make sure the benchmark result more accurate as loading the twiddle factors from DDR to on-chip memory is a once-work.